### PR TITLE
oauth2-clientd: make a message less threatening

### DIFF
--- a/oauth2_clientmanager/__init__.py
+++ b/oauth2_clientmanager/__init__.py
@@ -428,7 +428,7 @@ class OAuth2ClientManager:
                     except KeyboardInterrupt:
                         break
                 elif self.authurl:
-                    print("<canceled>\nResponse provided by browser session.")
+                    print("(not necessary any longer)\nResponse provided by browser session.\n")
                 if self.authurl:
                     break
 


### PR DESCRIPTION
When I first ran oauth2-clientd I was concerned seeing the following
where "canceled" seemed to indicate a problem:

  "Please enter the full callback URL: <canceled>
  Response provided by browser session."

Make this less threatening and also add a blank line to separate this
interactive portion from others.