### PR TITLE
cli: divide sleep time before refreshing token into threshold-long pe…

### DIFF
--- a/oauth2_clientd/cli.py
+++ b/oauth2_clientd/cli.py
@@ -72,7 +72,9 @@ def wait_for_refresh_timeout(oaclient: OAuth2ClientManager, thresh: int) -> None
 
     if timeout > 0:
         log.info(f"Waiting {int(timeout)}s to refresh token.")
-        time.sleep(timeout)
+        while timeout > 0:
+            time.sleep(min(timeout, thresh))
+            timeout = oaclient.access_token_expiry - thresh - time.time()
     else:
         log.info("Token has expired.")
 
@@ -175,7 +177,7 @@ def parse_arguments(config: ConfigParser) -> argparse.Namespace:
                         help='display loaded configuration and exit')
     parser.add_argument('-q', '--quiet', action='store_true', help='limit unnecessary output')
     parser.add_argument('-t', '--threshold', type=int, default=300,
-                        help='threshold before expiration to attempt to refresh tokens. (default=300s)')
+                        help='threshold before expiration to attempt to refresh tokens, also determines sleep granularity. (default=300s)')
     parser.add_argument('-u', '--update-hook', type=str, default=None,
                         help='path to command to call when token is updated (will receive access token on stdin)')
     parser.add_argument('--force', action='store_true', help='overwrite sessionfile if it exists')


### PR DESCRIPTION
…riods

When oauth2_clientd runs on a machine that gets suspended oauth2_clientd
does not update the token in a timely manner after the machine gets woken
up. Tokens stay valid for a period of time (usually an hour and 15
minutes). If the machine was suspended shortly after the token had been
renewed oauth2_clientd would wait almost all of the validity period to
renew the token again.

One possible solution is to divide the sleep time for which oauth2_clientd
blocks before refreshing the token into shorter periods. The threshold
parameter seems a natural choice since it has the advantage of not
introducing another time-related parameter.

Signed-off-by: Jiri Wiesner <jwiesner@suse.de>