### PR TITLE
cli: change importlib.resources module name

### DIFF
--- a/oauth2_clientd/cli.py
+++ b/oauth2_clientd/cli.py
@@ -13,7 +13,10 @@ import contextlib
 import subprocess
 import logging
 from configparser import ConfigParser
-import importlib.resources as pkg_resources
+if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 7):
+    import importlib_resources as pkg_resources
+else:
+    import importlib.resources as pkg_resources
 
 from typing import Any, Dict, List, Optional, TextIO, Union
 


### PR DESCRIPTION
The cli.py script could not be executed under OpenSUSE Leap 15.4:

Traceback (most recent call last):
  File "/home/jwiesner/bin/oauth2-clientd", line 4, in <module>
    __import__('pkg_resources').run_script('oauth2-clientd==0.6', 'oauth2-clientd')
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 1469, in run_script
    exec(script_code, namespace, namespace)
  File "/home/jwiesner/.local/lib/python3.6/site-packages/oauth2_clientd-0.6-py3.6.egg/EGG-INFO/scripts/oauth2-clientd", line 4, in <module>
    __import__('pkg_resources').run_script('oauth2-clientd==0.6', 'oauth2-clientd')
  File "/home/jwiesner/.local/lib/python3.6/site-packages/oauth2_clientd-0.6-py3.6.egg/oauth2_clientd/cli.py", line 16, in <module>
ModuleNotFoundError: No module named 'importlib.resources'

The resources submodule is not part of the importlib package in python
3.6. Both pip3 and zypper install the importlib_resources module.

Signed-off-by: Jiri Wiesner <jwiesner@suse.de>