### PR TITLE
cli: If attribute CLOCK_BOOTTIME doesn't exist fall back

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,4 +6,6 @@ Setup file for installation
 
 from setuptools import setup
 
-setup()
+setup(
+    package_data={'oauth2_clientd': ['data/*.conf']}
+)


### PR DESCRIPTION
time.CLOCK_BOOTTIME has only been introduced to the `time` module with Python 3.7. To support older versions, provide a fallback to time.CLOCK_MONOTONIC.

Fixes #10

Signed-off-by: Egbert Eich <eich@suse.com>