### PR TITLE
packaging: fix missing oauth2_clientd.data in installed package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = [ "oauth2_clientd" ]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"oauth2_clientd" = ["data/*.conf"]


### PR DESCRIPTION
This updates `pyproject.toml` to explicitly include the `oauth2_clientd.data` files in the package, ensuring they are available at runtime after installation.

Fixes: https://github.com/jeffmahoney/oauth2-clientd/issues/12